### PR TITLE
chore(release): 1.1.6 [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labshare/semantic-release-config",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Shared semantic-release configuration for LabShare Github projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Publish new version to resolve conflict with Github tags and Semantic Release detected versions.